### PR TITLE
Don't reload 'dwc2' overlay if already loaded

### DIFF
--- a/usr/lib/pt-display-port/ptusb0/setup/ptusb0-setup
+++ b/usr/lib/pt-display-port/ptusb0/setup/ptusb0-setup
@@ -18,6 +18,11 @@ interface_is_up() {
 }
 
 overlay_is_loaded() {
+	# using 'dtoverlay -l' isn't good enough to tell the state of an overlay
+	# since it only tracks overlays loaded via 'dtoverlay' on runtime;
+	# some overlays are loaded on boot by the kernel according
+	# to /boot/config.txt and won't show up in 'dtoverlay -l'
+	
 	overlay_name="${1}"
 	status_file=""
 
@@ -47,9 +52,19 @@ unload_overlay() {
 
 load_overlay() {
 	overlay_name="${1}"
-	unload_overlay "${overlay_name}"
+
+	if overlay_is_loaded "${overlay_name}"; then
+		echo "Overlay ${overlay_name} already loaded"
+		return
+	fi
+
 	echo "Loading ${overlay_name} dtoverlay"
 	dtoverlay "${overlay_name}"
+
+	if ! overlay_is_loaded "${overlay_name}"; then
+		echo "Overlay ${overlay_name} isn't loaded"
+	fi
+
 	sleep 1
 }
 


### PR DESCRIPTION
Stop reloading `dwc2` overlay if already loaded. Forcing an unload and load on runtime causes issues with the miniscreen serial connection:
```
self._write_bytes(list(cmd))
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/core/contrib/luma/core/interface/serial.py", line 208, in _write_bytes
    self._display(image)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/core/contrib/luma/oled/device/__init__.py", line 82, in display
    self._spi.writebytes(data)
BrokenPipeError    : [Errno 108] Cannot send after transport endpoint shutdownself.command(set_page_address, 0x02, 0x10)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/core/contrib/luma/core/device.py", line 32, in command
    self._serial_interface.command(*cmd)
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/core/contrib/luma/core/interface/serial.py", line 82, in command
    self._write_bytes(list(cmd))
  File "/usr/lib/python3/dist-packages/pitop/miniscreen/oled/core/contrib/luma/core/interface/serial.py", line 208, in _write_bytes
    self._spi.writebytes(data)
BrokenPipeError: [Errno 108] Cannot send after transport endpoint shutdown

``` 