### PR TITLE
Restart dhcp service on failure

### DIFF
--- a/lib/systemd/system/isc-dhcp-server.service.d/10-configure-for-ptusb0.conf
+++ b/lib/systemd/system/isc-dhcp-server.service.d/10-configure-for-ptusb0.conf
@@ -3,3 +3,4 @@ ExecStartPre=/usr/bin/raspi-config nonint is_pifour
 ExecStartPre=/usr/lib/pt-display-port/ptusb0/setup/ptusb0-setup
 ExecStartPre=/usr/lib/pt-display-port/dhcp-server/setup/dhcp-server-setup
 ExecStartPre=/bin/sleep 2
+Restart=on-failure


### PR DESCRIPTION
Modify `isc-dhcp-server` unit file to restart the service on error.